### PR TITLE
fix regexp for ToDos in HTML comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 				"todo-tree.regex": {
 					"type": "string",
 					"description": "Regular expression for matching TODOs",
-					"default": "(//|#|<--|;)\\s*(TODO|FIXME)"
+					"default": "(//|#|<!--|;)\\s*(TODO|FIXME)"
 				},
 				"todo-tree.rootFolder": {
 					"type": "string",


### PR DESCRIPTION
Added exclamation mark for TODO comments. 
The default configuration does not match ToDos in HTML files.