### PR TITLE
Made the rgPath value dynamic

### DIFF
--- a/ripgrep.js
+++ b/ripgrep.js
@@ -65,7 +65,7 @@ module.exports = function ripGrep( cwd, options, searchTerm )
     options.globs = options.globs || [];
     options.string = searchTerm || options.string || '';
 
-    var rgPath = vscode.workspace.getConfiguration( 'todo-tree' ).ripgrep;
+    var rgPath = options.rgPath;
     var isWin = /^win/.test( process.platform );
 
     if( !fs.existsSync( rgPath ) )


### PR DESCRIPTION
I am using the same settings.json for VS Code on Linux and OSX. The
`todo-tree.ripgrep` setting was making my `settings.json` platform
specific.

This change calculates `rgPath` on the fly rather than updating
`settings.json`.

We may want to memoize `getRgPath()` to eliminate the fs lookup
everytime `getRgPath()` is called.