### PR TITLE
Add maxBuffer setting to control buffer size for ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The extension can be customised as follows:
 | todo&#8209;tree.globs | <tt>[]</tt> | If you want to modify the files which are searched, you can define a list of <a href="https://www.npmjs.com/package/glob">globs</a>.|
 | todo&#8209;tree.ripgrep | <tt>""</tt> | Normally, the extension will locate ripgrep itself as and when required. If you want to use an alternate version of ripgrep, set this to point to wherever it is installed. |
 | todo&#8209;tree.ripgrepArgs | <tt>""</tt> | Use this to pass additional arguments to ripgrep. e.g. <tt>"-i"</tt> to make the search case insensitive. *Use with caution!* |
+| todo&#8209;tree.ripgrepMaxBuffer | <tt>200</tt> | By default, the ripgrep process will have a buffer of 200KB. However, this is sometimes not enough for all the tags you might want to see. This setting can be used to increase the buffer size accordingly. |
 | todo&#8209;tree.expanded | <tt>false</tt> | If you want the tree to be opened with all nodes expanded, set this to true. By default, the tree will be collapsed. |
 | todo&#8209;tree.flat | <tt>false</tt> | Set to true to show the tree as a flat list of files (with folder names in brackets). |
 | todo&#8209;tree.icons | <tt>{}</tt> | Use alternative icons from the octicon set for specific tags, e.g. <tt>{"TODO":"pin", "FIXME":"issue-opened"}</tt> |

--- a/extension.js
+++ b/extension.js
@@ -311,7 +311,8 @@ function activate( context )
         }
 
         options.outputChannel = outputChannel;
-        options.additional = vscode.workspace.getConfiguration( 'todo-tree' ).ripgrepArgs;
+        options.additional = config.ripgrepArgs;
+        options.maxBuffer = config.ripgrepMaxBuffer;
 
         return options;
     }
@@ -603,6 +604,7 @@ function activate( context )
                     e.affectsConfiguration( "todo-tree.regex" ) ||
                     e.affectsConfiguration( "todo-tree.ripgrep" ) ||
                     e.affectsConfiguration( "todo-tree.ripgrepArgs" ) ||
+                    e.affectsConfiguration( "todo-tree.ripgrepMaxBuffer" ) ||
                     e.affectsConfiguration( "todo-tree.rootFolder" ) ||
                     e.affectsConfiguration( "todo-tree.showTagsFromOpenFilesOnly" ) ||
                     e.affectsConfiguration( "todo-tree.tags" ) )

--- a/package.json
+++ b/package.json
@@ -289,6 +289,11 @@
                     "type": "boolean",
                     "description": "Disable scanning of the workspace for TODOs",
                     "default": false
+                },
+                "todo-tree.ripgrepMaxBuffer": {
+                    "type": "integer",
+                    "description": "Size of the buffer to use for retrieving output from ripgrep (kilobytes)",
+                    "default": 200
                 }
             }
         }


### PR DESCRIPTION
Fixes #50 

This PR adds an additional setting: `todo-tree.ripgrepMaxBuffer`.

This new setting allows the stdout buffer size for ripgrep to be configured in kilobytes, allowing a user to override the default 200kB.

In addition, this adds some additional output to the `outputChannel` so that any error or stderr output during the running of ripgrep can be seen when debugging the extension.

There are also a couple of tidy ups in the code (added a space, reused an existing call to retrieve configuration rather than requesting a second time).