### PR TITLE
Added a hyperlink in the readme to github octicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Both `defaultHighlight` and `customHighlight` allow for the following settings:
 
 Foreground and background colours can be one of "red", "green", "blue", "yellow", "magenta", "cyan", "grey", "white" or "black". RGB values can also be used (e.g. "#80FF00").
 
-`icon` - used to set a different icon in the tree view. Must be a valid octicon - will default to a tick if it's not.
+`icon` - used to set a different icon in the tree view. Must be a valid [octicon](https://octicons.github.com/) - will default to a tick if it's not.
 
 `iconColour` - used to set the colour of the icon in the tree. If not specified, it will try to use the foreground colour, the background colour and then the older settings, in that order.
 


### PR DESCRIPTION
This gives readers a direct link to the official source with examples of octicons they can use.