### PR TITLE
Remove colon from ${after} for label format

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -78,6 +78,23 @@ QUnit.test( "utils.extractTag returns the tag offset", function( assert )
     assert.equal( result.tagOffset, 7 );
 } );
 
+QUnit.test( "utils.extractTag remove colon from ${after}", function( assert )
+{
+    var testConfig = stubs.getTestConfig();
+    utils.init( testConfig );
+
+    result = utils.extractTag( "before TODO: after" );
+    assert.equal( result.withoutTag, "after" );
+
+    result = utils.extractTag( "before TODO : after" );
+    assert.equal( result.withoutTag, "after" );
+
+    result = utils.extractTag( "before TODO :after" );
+    assert.equal( result.withoutTag, "after" );
+    result = utils.formatLabel("${tag}: ${after}", { tag: result.tag, after: result.withoutTag })
+    assert.equal( result, "TODO: after" );
+} );
+
 QUnit.test( "utils.getRegexSource returns the regex source without expanded tags if they aren't present", function( assert )
 {
     var testConfig = stubs.getTestConfig();

--- a/utils.js
+++ b/utils.js
@@ -94,8 +94,7 @@ function extractTag( text )
         if( tagMatch )
         {
             tagOffset = tagMatch.index;
-            text = text.substr( tagMatch.index );
-            text = text.substr( tagMatch[ 0 ].length );
+            text = text.substr( tagMatch.index + tagMatch[ 0 ].length ).trim().replace(/^:\s*/, "");
             c.tags.map( function( tag )
             {
                 if( tag.toLowerCase() == tagMatch[ 0 ].toLowerCase() )
@@ -106,7 +105,7 @@ function extractTag( text )
         }
     }
 
-    return { tag: tagMatch ? originalTag : "", withoutTag: text.trim(), tagOffset: tagOffset };
+    return { tag: tagMatch ? originalTag : "", withoutTag: text, tagOffset: tagOffset };
 }
 
 function getRegexSource()


### PR DESCRIPTION
For example:
```
// TODO after
// TODO : after
// TODO: after
// TODO :afte
```

Before (*todo-tree.labelFormat: "${after}"*):
![Screenshot from 2019-04-17 17-17-52](https://user-images.githubusercontent.com/8409258/56295295-3a40d880-6135-11e9-9c37-839f78bcd41b.png)
After:
![Screenshot from 2019-04-17 17-20-44](https://user-images.githubusercontent.com/8409258/56295297-3a40d880-6135-11e9-8d81-9eba2740c6d4.png)

Before (*"${tag} ${after}"*):
![Screenshot from 2019-04-17 17-18-49](https://user-images.githubusercontent.com/8409258/56295738-e387ce80-6135-11e9-9e58-d45ba8848890.png)
After:
![Screenshot from 2019-04-17 17-20-33](https://user-images.githubusercontent.com/8409258/56295740-e387ce80-6135-11e9-9306-f173fdd80a8a.png)
In order not to complicate a logic of code, a compromise was needed, the essence of which is that all those who want to see a colon will need to use **"$ {tag}: $ {after}"**. As a plus, formatting is now the same for each label.
![Screenshot from 2019-04-17 17-19-53](https://user-images.githubusercontent.com/8409258/56295748-e5ea2880-6135-11e9-89c8-a4249d7cfbdc.png)

