### PR TITLE
Build globs for ripgrep from our two sets of globs

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -220,15 +220,9 @@ function activate( context )
     }
 
     function buildGlobs(includeGlobs, excludeGlobs) {
-        const globs = [];
-        for( const glob of includeGlobs ) {
-            globs.push(glob);
-        }
-
-        for( const glob of excludeGlobs ) {
-            globs.push(`!${glob}`);
-        }
-        return globs;
+        return []
+            .concat(includeGlobs)
+            .concat(excludeGlobs.map(g => `!${g}`));
     }
 
     function getOptions( filename )

--- a/extension.js
+++ b/extension.js
@@ -219,6 +219,18 @@ function activate( context )
         } );
     }
 
+    function buildGlobs(includeGlobs, excludeGlobs) {
+        const globs = [];
+        for( const glob of includeGlobs ) {
+            globs.push(glob);
+        }
+
+        for( const glob of excludeGlobs ) {
+            globs.push(`!${glob}`);
+        }
+        return globs;
+    }
+
     function getOptions( filename )
     {
         var c = vscode.workspace.getConfiguration( 'todo-tree' );
@@ -227,7 +239,7 @@ function activate( context )
             regex: "\"" + utils.getRegexSource() + "\"",
             rgPath: config.ripgrepPath()
         };
-        var globs = c.globs;
+        var globs = buildGlobs(c.includeGlobs, c.excludeGlobs);
         if( globs && globs.length > 0 )
         {
             options.globs = globs;

--- a/package.json
+++ b/package.json
@@ -405,8 +405,8 @@
                 },
                 "todo-tree.showScanOpenFilesOrWorkspaceButton": {
                     "type": "boolean",
-                    "default":false,
-                    "markdownDescription":"Show a button on the tree view header to toggle between scanning open files only, or the whole workspace"
+                    "default": false,
+                    "markdownDescription": "Show a button on the tree view header to toggle between scanning open files only, or the whole workspace"
                 }
             }
         }


### PR DESCRIPTION
This change updates the options being built for ripgrep by ensuring that the `includeGlobs` and `excludeGlobs` are provided. This way, ripgrep limits what it processes based on the settings. This is especially useful on large projects as it can cut out a large number of files from even being processed, rather than applying the globs after the execution of ripgrep.