### PR TITLE
Add a "reveal behaviour" setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The extension can be customised as follows:
 | todo-tree.ripgrepArgs | <tt>"--max-columns=1000"</tt> | Use this to pass additional arguments to ripgrep. e.g. <tt>"-i"</tt> to make the search case insensitive. *Use with caution!* |
 | todo-tree.ripgrepMaxBuffer | <tt>200</tt> | By default, the ripgrep process will have a buffer of 200KB. However, this is sometimes not enough for all the tags you might want to see. This setting can be used to increase the buffer size accordingly. |
 | todo-tree.showInExplorer | <tt>true</tt> | The tree is shown in the explorer view and also has it's own view in the activity bar. If you no longer want to see it in the explorer view, set this to false. |
+| todo-tree.revealBehaviour | <tt>"start"</tt> | Change the cursor behaviour when selecting a todo from the expolorer. You can choose from: `start` (Moves the cursor to the begining of the todo), `end` (Moves the cursor to the end of the todo) and `highlight` (Selects the todo text).
 | todo-tree.filterCaseSensitive | <tt>false</tt> | Use this if you need the filtering to be case sensitive. *Note: this does not the apply to the search*. |
 | todo-tree.highlightDelay | <tt>500</tt> | The delay before highlighting (milliseconds). |
 | todo-tree.trackFile | <tt>true</tt> | Set to false if you want to prevent tracking the open file in the tree view. |

--- a/extension.js
+++ b/extension.js
@@ -634,15 +634,33 @@ function activate( context )
             return;
         }
 
-        context.subscriptions.push( vscode.commands.registerCommand( 'todo-tree.revealTodo', ( file, line ) =>
+        context.subscriptions.push( vscode.commands.registerCommand( 'todo-tree.revealTodo', ( file, line, column, length ) =>
         {
             selectedDocument = file;
             vscode.workspace.openTextDocument( file ).then( function( document )
             {
                 vscode.window.showTextDocument( document ).then( function( editor )
                 {
-                    var position = new vscode.Position( line, 0 );
-                    editor.selection = new vscode.Selection( position, position );
+                    var selectionStart, selectionEnd;
+                    var todoStart = new vscode.Position( line, column - 1 );
+                    var todoEnd = new vscode.Position( line, column - 1 + length );
+                    var revealBehaviour = vscode.workspace.getConfiguration( 'todo-tree' ).get( 'revealBehaviour' );
+
+                    if (revealBehaviour == "end")
+                    {
+                        selectionStart = todoEnd;
+                        selectionEnd = todoEnd;
+                    } else if (revealBehaviour == "highlight")
+                    {
+                        selectionStart = todoStart;
+                        selectionEnd = todoEnd;
+                    } else
+                    {
+                        selectionStart = todoStart;
+                        selectionEnd = todoStart;
+                    }
+
+                    editor.selection = new vscode.Selection( selectionStart, selectionEnd );
                     editor.revealRange( editor.selection, vscode.TextEditorRevealType.InCenter );
                     vscode.commands.executeCommand( 'workbench.action.focusActiveEditorGroup' );
                 } );

--- a/extension.js
+++ b/extension.js
@@ -634,7 +634,7 @@ function activate( context )
             return;
         }
 
-        context.subscriptions.push( vscode.commands.registerCommand( 'todo-tree.revealTodo', ( file, line, column, length ) =>
+        context.subscriptions.push( vscode.commands.registerCommand( 'todo-tree.revealTodo', ( file, line, column, endColumn ) =>
         {
             selectedDocument = file;
             vscode.workspace.openTextDocument( file ).then( function( document )
@@ -643,7 +643,7 @@ function activate( context )
                 {
                     var selectionStart, selectionEnd;
                     var todoStart = new vscode.Position( line, column - 1 );
-                    var todoEnd = new vscode.Position( line, column - 1 + length );
+                    var todoEnd = new vscode.Position( line, endColumn - 1 );
                     var revealBehaviour = vscode.workspace.getConfiguration( 'todo-tree' ).get( 'revealBehaviour' );
 
                     if (revealBehaviour == "end")

--- a/package.json
+++ b/package.json
@@ -296,6 +296,11 @@
                     "default": true,
                     "markdownDescription": "Show the tree in the explorer view"
                 },
+                "todo-tree.revealBehaviour": {
+                    "type": "string",
+                    "default": "start",
+                    "markdownDescription": "Sets where the cursor is positioned when revealing a todo"
+                },
                 "todo-tree.filterCaseSensitive": {
                     "type": "boolean",
                     "default": false,
@@ -405,8 +410,8 @@
                 },
                 "todo-tree.showScanOpenFilesOrWorkspaceButton": {
                     "type": "boolean",
-                    "default":false,
-                    "markdownDescription":"Show a button on the tree view header to toggle between scanning open files only, or the whole workspace"
+                    "default": false,
+                    "markdownDescription": "Show a button on the tree view header to toggle between scanning open files only, or the whole workspace"
                 }
             }
         }

--- a/tree.js
+++ b/tree.js
@@ -148,7 +148,7 @@ function createTodoNode( result )
         tag: extracted.tag,
         line: result.line - 1,
         column: result.column,
-        length: result.match.length,
+        endColumn: result.column + result.match.length,
         after: extracted.withoutTag.trim(),
         before: result.match.substring( 0, result.column - 1 ).trim(),
         id: id,
@@ -432,7 +432,7 @@ class TreeNodeProvider
                         node.fsPath,
                         node.line,
                         node.column,
-                        node.length
+                        node.endColumn
                     ]
                 };
             }

--- a/tree.js
+++ b/tree.js
@@ -148,6 +148,7 @@ function createTodoNode( result )
         tag: extracted.tag,
         line: result.line - 1,
         column: result.column,
+        length: result.match.length,
         after: extracted.withoutTag.trim(),
         before: result.match.substring( 0, result.column - 1 ).trim(),
         id: id,
@@ -429,7 +430,9 @@ class TreeNodeProvider
                     title: "",
                     arguments: [
                         node.fsPath,
-                        node.line
+                        node.line,
+                        node.column,
+                        node.length
                     ]
                 };
             }


### PR DESCRIPTION
**Existing Behaviour**

Currently, when clicking on a 'todo' in the explorer window, the extension navigates to the beginning of the line on which that 'todo' is located.

**New Behaviour**

This PR adds a `revealBehaviour` setting to the extension. This allows you to control how the extension will navigate to the 'todo'. There are currently 3 options:
- `"start"` - Places the cursor at the start of the 'todo' text.
- `"end"` - Places the cursor at the end of the 'todo' text.
- `"highlight"` - Selects the 'todo' text.

More options could be added, but these seemed like a good base.

**Considerations**

- I'm happy to change the name of the setting or any variables. The name `revealBehaviour` came from the existing command `revealTodo`.
- I wasn't sure if you'd want to keep the existing behaviour of navigating to column 0 as an option. We can add this back in if so.
- I have tried my best to keep to your code-style. Please let me know if you'd like anything changed.
- I thought about changing the variable `node.column`'s name to `node.start`, so that we could have `start` and `end` variables for the 'todo' text, but the 'todo' label is also dependant on `node.column`, so I decided to name the additional variable `endColumn` instead.
- I have not committed the `package-lock.json` as I see that it's not currently in the repo.
- `npm` seems to have added a bit of whitespace to the `package.json` automatically - I have left this in.