### PR TITLE
Fix VS Code installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can install the latest version of the extension via the Visual Studio Market
 
 Alternatively, open Visual Studio code, press `Ctrl+P` or `Cmd+P` and type:
 
-    > ext install todo-tree
+    > ext install Gruntfuggly.todo-tree
 
 *Note: Don't forget to reload the window to activate the extension!*
 


### PR DESCRIPTION
`ext install todo-tree` doesn't work, `ext install Gruntfuggly.todo-tree` does.