### PR TITLE
Faster, more accurate and more robust regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,7 +430,7 @@
                 },
                 "todo-tree.regex.regex": {
                     "type": "string",
-                    "default": "((//|#|<!--|;|/\\*|^)\\s*($TAGS)|^\\s*- \\[ \\])",
+                    "default": "((//|#|(^|[ \\t]+)--|<!--|;|(/|^[ \\t]*)\\*+|^)[ \\t]*@?($TAGS)\\b|^[ \\t]*- \\[ \\])",
                     "markdownDescription": "Regular expression for matching TODOs. Note: $TAGS will be replaced by the tag list."
                 },
                 "todo-tree.regex.regexCaseSensitive": {

--- a/package.json
+++ b/package.json
@@ -325,8 +325,9 @@
                 "todo-tree.general.tags": {
                     "type": "array",
                     "default": [
-                        "TODO",
-                        "FIXME"
+                        "BUG",
+                        "FIXME",
+                        "TODO"
                     ],
                     "items": {
                         "type": "string"
@@ -469,7 +470,14 @@
                 },
                 "todo-tree.highlights.customHighlight": {
                     "type": "object",
-                    "default": {},
+                    "default": {
+                        "FIXME": {
+                            "icon": "flame"
+                        },
+                        "BUG": {
+                            "icon": "bug"
+                        }
+                    },
                     "markdownDescription": "Custom configuration for highlighting, [Read more...](https://github.com/Gruntfuggly/todo-tree#highlighting)"
                 },
                 "todo-tree.tree.filterCaseSensitive": {

--- a/utils.js
+++ b/utils.js
@@ -146,6 +146,21 @@ function getRegexSource()
     return regex;
 }
 
+function getRegexSourceFaster()
+{
+    /*
+    Replaces all unescaped "(" capturing groups with "(?:" non-capturing groups
+    instead, which doubles performance of the JS regex engine when searching.
+    Our replacement pattern uses negative lookbehind + lookahead to ensure
+    that it never matches escaped "\(" chars or already-modified "(?" groups.
+    Group 1 in the substitution contains any preceding NON-escaping "\".
+    */
+    var regex = getRegexSource();
+    regex = regex.replace( /(?<!\\)((?:\\\\)*)\((?!\?)/g, "$1(?:" );
+
+    return regex;
+}
+
 function getRegexForEditorSearch()
 {
     var flags = 'gm';
@@ -154,8 +169,8 @@ function getRegexForEditorSearch()
         flags += 'i';
     }
 
-    var source = getRegexSource();
-    return RegExp( source, flags );
+    // JavaScript regex performance is doubled by using the faster regex.
+    return RegExp( getRegexSourceFaster(), flags );
 }
 
 function getRegexForRipGrep()
@@ -166,6 +181,7 @@ function getRegexForRipGrep()
         flags += 'i';
     }
 
+    // RipGrep doesn't accept "(?:)" groups, so we'll send the regular regex.
     return RegExp( getRegexSource(), flags );
 }
 
@@ -243,6 +259,7 @@ module.exports.hexToRgba = hexToRgba;
 module.exports.removeBlockComments = removeBlockComments;
 module.exports.extractTag = extractTag;
 module.exports.getRegexSource = getRegexSource;
+module.exports.getRegexSourceFaster = getRegexSourceFaster;
 module.exports.getRegexForRipGrep = getRegexForRipGrep;
 module.exports.getRegexForEditorSearch = getRegexForEditorSearch;
 module.exports.isIncluded = isIncluded;


### PR DESCRIPTION
The default regex was sort of making me itch, as someone who's the "go-to guy" for writing correct regex patterns. It had lots of room for improvement, to increase accuracy and support more languages, and improve speed. This contribution takes care of the pattern once and for all.

Closes #189 
Closes #47

Supersedes almost all "alternative language" code in the [wiki](https://github.com/Gruntfuggly/todo-tree/wiki/Configuration-Examples), making the wiki nearly pointless. Only the Ocaml and PQSL sections in the wiki remain relevant after these changes. Those languages' comment patterns are a bit too esoteric for general inclusion in the regex, in my opinion, and should remain in the wiki.

Commit message below:

---

Enhances the default regex to support more programming languages while
also increasing the ACCURACY and PERFORMANCE by adding bounds checks
and other correctness checks.

All `\s` (whitespace) selectors are now replaced with higher-performing
and more accurate `[ \\t]` (spaces and tabs). JavaScript lacks Perl's
`\h` selector for "horizontal whitespace", so we MUST be more explicit
here to get the same benefits. Why this change? Because `\s` matches new
lines, which means that the entire matching slows down and breaks since
it also checks across line boundaries, which is very bad. So we MUST use
`[ \\t]` for correctness. And programming only uses spaces or tabs, so
we don't need the additional Unicode Whitespace that Perl's `\h` has.

This new regex looks for one of the following:
(When we say "whitespace" below, we only mean spaces or tabs.)

1. `//` (most languages; is unique enough to not need extra bounds...
   is used for "integer division" in some languages, but that's rare
   in actual code, and wouldn't be a false positive anyway since the
   user would ALSO have to put a tag word after their "//" operator)
2. `#` (Python, etc)
3. `<start of line, OR one or more whitespace>--` (Lua etc; the spaces
   increase speed and avoids false positives from syntax
   such as "i--" or "--i".)
4. `<!--` (XML/HTML)
5. `;`
6. `<either "/", OR "start-of-line followed by zero or more
    whitespace"><1 or more "*">` (this matches multiline comments;
    matches "/***** TODO", "* TODO", etc and completely avoids false
    positives. there are no risks thanks to the strict pattern.)
7. `<start of line>` (this is a strict pattern and ensures that we
    are able to match tags within multiline comments, such as inside
    the XML/HTML `<!-- lines... -->` blocks.)

When one of the patterns above match, we check that it's followed by
ALL of the below:

1. `<zero or more whitespace>` (this handles the fact that some
   people like to write `//TODO` and other people write `// TODO`.)
2. Then `<optional "@">` (this handles the `@todo` syntax used in
   JavaDoc, JavaScript, PHP, etc. but note that we still need to
   extend the default tags with lowercase variants if we want to
   actually match them)
3. Then it matches any of the tags.
4. Then `\b` which performs a boundary check to ensure that nothing
   follows after the matched tag. So "// NOTE:" and "// NOTE" will
   match, but not "// NOTEDHEHE".

Lastly, we have the alternative pattern which looks for a markdown
"todo" list item, as seen before `^[ \\t]*- \\[ \\])` (with the
only modification being the improved whitespace pattern here).