### PR TITLE
Fixed tooltipFormat always displaying default

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -454,7 +454,7 @@ class TreeNodeProvider
                 treeItem.resourceUri = vscode.Uri.file( node.fsPath );
             }
 
-            if( treeItem.type === TODO )
+            if( treeItem.node.type === TODO )
             {
                 treeItem.tooltip = config.tooltipFormat();
                 treeItem.tooltip = utils.formatLabel( config.tooltipFormat(), node );


### PR DESCRIPTION
The tooltipFormat configuration was always using the default value. The "type" property that was being checked for was inside of the node object therefore the "todo" type was never matched and the custom format was never used. 