### PR TITLE
Remove references to treeViewExplorer and showInExplorer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,6 @@ Use this to pass additional arguments to ripgrep. e.g. `"-i"` to make the search
 **todo-tree.ripgrep.ripgrepMaxBuffer** (`200`)<br/>
 By default, the ripgrep process will have a buffer of 200KB. However, this is sometimes not enough for all the tags you might want to see. This setting can be used to increase the buffer size accordingly.
 
-**todo-tree.tree.showInExplorer** (`true`)<br/>
-The tree is shown in the explorer view and also has it's own view in the activity bar. If you no longer want to see it in the explorer view, set this to false.
-
 **todo-tree.tree.hideTreeWhenEmpty** (`true`)<br/>
 Normally, the tree is removed from the explorer view if nothing is found. Set this to false to keep the view present.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "todo-tree",
-    "version": "0.0.186",
+    "version": "0.0.188",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "Other"
     ],
     "activationEvents": [
-        "*"
+        "onStartupFinished"
     ],
     "main": "./dist/extension",
     "contributes": {

--- a/package.json
+++ b/package.json
@@ -34,23 +34,17 @@
             "activitybar": [
                 {
                     "id": "todo-tree-container",
-                    "title": "TODOs",
+                    "title": "TODO Tree",
                     "icon": "resources/todo-tree-container.svg"
                 }
             ]
         },
         "views": {
-            "explorer": [
-                {
-                    "id": "todo-tree-view-explorer",
-                    "name": "TODOs",
-                    "when": "todo-tree-has-content && todo-tree-in-explorer"
-                }
-            ],
             "todo-tree-container": [
                 {
                     "id": "todo-tree-view",
-                    "name": "TODOs"
+                    "name": "TODOs",
+                    "when": "todo-tree-has-content"
                 }
             ]
         },
@@ -647,11 +641,6 @@
                 "todo-tree.tree.showCountsInTree": {
                     "default": false,
                     "markdownDescription": "Show counts of TODOs in the tree",
-                    "type": "boolean"
-                },
-                "todo-tree.tree.showInExplorer": {
-                    "default": true,
-                    "markdownDescription": "Show the tree in the explorer view",
                     "type": "boolean"
                 },
                 "todo-tree.tree.showScanModeButton": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ],
     "version": "0.0.188",
     "license": "MIT",
-    "icon": "resources/todo-tree.png",
+    "icon": "https://github.com/Gruntfuggly/todo-tree/blob/master/resources/todo-tree.png",
     "publisher": "Gruntfuggly",
     "engines": {
         "vscode": "^1.5.0"

--- a/src/extension.js
+++ b/src/extension.js
@@ -59,14 +59,12 @@ function activate( context )
     provider = new tree.TreeNodeProvider( context, debug );
     var status = vscode.window.createStatusBarItem( vscode.StatusBarAlignment.Left, 0 );
 
-    var todoTreeViewExplorer = vscode.window.createTreeView( "todo-tree-view-explorer", { treeDataProvider: provider } );
     var todoTreeView = vscode.window.createTreeView( "todo-tree-view", { treeDataProvider: provider } );
 
     var fileSystemWatcher;
 
     context.subscriptions.push( provider );
     context.subscriptions.push( status );
-    context.subscriptions.push( todoTreeViewExplorer );
     context.subscriptions.push( todoTreeView );
 
     context.subscriptions.push( vscode.workspace.registerTextDocumentContentProvider( 'todotree-export', {
@@ -270,12 +268,7 @@ function activate( context )
     {
         if( config.clickingStatusBarShouldRevealTree() )
         {
-            var showInExplorer = vscode.workspace.getConfiguration( 'todo-tree.tree' ).showInExplorer;
-            if( showInExplorer === true )
-            {
-                todoTreeViewExplorer.reveal( provider.getFirstNode(), { focus: false, select: false } );
-            }
-            if( todoTreeView.visible === false && showInExplorer === false )
+            if( todoTreeView.visible === false )
             {
                 vscode.commands.executeCommand( 'workbench.view.extension.todo-tree-container' );
             }
@@ -574,7 +567,6 @@ function activate( context )
 
     function rebuild()
     {
-        todoTreeViewExplorer.message = "";
         todoTreeView.message = "";
 
         searchResults = [];
@@ -921,14 +913,6 @@ function activate( context )
                 }
             }
 
-            function isUnset( settingName )
-            {
-                var setting = vscode.workspace.getConfiguration( 'todo-tree' ).inspect( settingName );
-                return setting.globalValue === undefined &&
-                    setting.workspaceValue === undefined &&
-                    setting.workspaceFolderValue === undefined;
-            }
-
             var c = vscode.workspace.getConfiguration( 'todo-tree' );
             var migrated = false;
 
@@ -958,7 +942,6 @@ function activate( context )
             migrateIfRequired( 'rootFolder', 'string', 'general' );
             migrateIfRequired( 'showBadges', 'boolean', 'tree' );
             migrateIfRequired( 'showCountsInTree', 'boolean', 'tree' );
-            migrateIfRequired( 'showInExplorer', 'boolean', 'tree' );
             migrateIfRequired( 'sortTagsOnlyViewAlphabetically', 'boolean', 'tree' );
             migrateIfRequired( 'statusBar', 'string', 'general' );
             migrateIfRequired( 'statusBarClickBehaviour', 'string', 'general' );
@@ -1004,10 +987,6 @@ function activate( context )
         {
             provider.getElement( uri.fsPath, function( element )
             {
-                if( todoTreeViewExplorer.visible === true )
-                {
-                    todoTreeViewExplorer.reveal( element, { focus: false, select: true } );
-                }
                 if( todoTreeView.visible === true )
                 {
                     todoTreeView.reveal( element, { focus: false, select: true } );
@@ -1323,9 +1302,7 @@ function activate( context )
             vscode.workspace.getConfiguration( 'todo-tree.tree' ).update( 'showBadges', !current, vscode.ConfigurationTarget.Workspace );
         } ) );
 
-        context.subscriptions.push( todoTreeViewExplorer.onDidExpandElement( function( e ) { provider.setExpanded( e.element.fsPath, true ); } ) );
         context.subscriptions.push( todoTreeView.onDidExpandElement( function( e ) { provider.setExpanded( e.element.fsPath, true ); } ) );
-        context.subscriptions.push( todoTreeViewExplorer.onDidCollapseElement( function( e ) { provider.setExpanded( e.element.fsPath, false ); } ) );
         context.subscriptions.push( todoTreeView.onDidCollapseElement( function( e ) { provider.setExpanded( e.element.fsPath, false ); } ) );
 
         context.subscriptions.push( vscode.commands.registerCommand( 'todo-tree.filterClear', clearTreeFilter ) );
@@ -1507,7 +1484,6 @@ function activate( context )
                     refresh();
                 }
 
-                vscode.commands.executeCommand( 'setContext', 'todo-tree-in-explorer', vscode.workspace.getConfiguration( 'todo-tree.tree' ).showInExplorer );
                 setButtonsAndContext();
             }
         } ) );
@@ -1525,8 +1501,6 @@ function activate( context )
         } ) );
 
         context.subscriptions.push( outputChannel );
-
-        vscode.commands.executeCommand( 'setContext', 'todo-tree-in-explorer', vscode.workspace.getConfiguration( 'todo-tree.tree' ).showInExplorer );
 
         resetOutputChannel();
 
@@ -1558,7 +1532,6 @@ function activate( context )
         }
         else
         {
-            todoTreeViewExplorer.message = "Click the refresh button to scan...";
             todoTreeView.message = "Click the refresh button to scan...";
         }
     }


### PR DESCRIPTION
I believe 2 TODO Trees in the explorer and Activity Bar to be an anti-pattern.

This PR removes the treeViewExplorer in favor of a draggable TODO Tree Activity Bar view that can be shown in the explorer, Activity Bar, or anywhere else in VSCode.

Fixes #395 