### PR TITLE
Implement custom regex for the right side of tags

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "ut",
             "type": "shell",
-            "command": "qunit test/tests.js",
+            "command": "qunit -c src/utils.js -c src/attributes.js -t test/tests.js",
             "presentation": {
                 "reveal": "always"
             },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Todo Tree Change Log
 
 - Add support for a simple colour scheme to apply to the highlights
+- Default to 'TODO' if all tags are removed
 
 ## v0.0.192 - 2020-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Todo Tree Change Log
 
+- Add support for a simple colour scheme to apply to the highlights
+
 ## v0.0.192 - 2020-12-10
 
 - Use unique filenames for pattern files

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Found TODOs can also be highlighted in open files.
 
 ## Highlighting
 
+>*New!:* If you just want to set different colours for tags, you can now enable `todo-tree.highlights.useColourScheme`. This will apply a set of colours (which can be changed) to the tags in the order that they are defined.
+
 Highlighting tags is configurable. Use `defaultHighlight` to set up highlights for all tags. If you need to configure individual tags differently, use `customHighlight`. If settings are not specified in `customHighlight`, the value from `defaultHighlight` is used. If a setting is not specified in `defaultHighlight` then the older, deprecated `icon`, `iconColour` and `iconColours` settings are used.
 
 Both `defaultHighlight` and `customHighlight` allow for the following settings:
@@ -250,6 +252,15 @@ Set highlights per tag (or tag group). Example:
 
 **todo-tree.highlights.schemes** (`['file','untitled']`)<br/>
 Editor schemes to show highlights in. To show highlights in settings files, for instance, add `vscode-userdata` or for output windows, add `output`.
+
+**todo-tree.highlights.useColourScheme** (`false`)<br/>
+Use a simple scheme for colouring highlights. This will simply apply a list of colours in the same order as the tags are defined. Use this as a much simpler alternative to setting up custom highlights for each tag. *Note: The colour scheme overrides the colours defined in* `todo-tree.highlights.defaultHighlight` *but not* `todo-tree.highlights.customHighlight`*.*
+
+**todo-tree.highlights.backgroundColourScheme** (`["red","orange","yellow","green","blue","indigo","violet"]`)<br/>
+Defines colours for use in conjunction with `todo-tree.highlights.useColourScheme` to colour highlights. Colours can be defined in the same way as other colours (e.g. hex code, theme names, etc.). If there are more tags than colours, the sequence is repeated.
+
+**todo-tree.highlights.foreroundColourScheme** (`["white","black","black","white","white","white","black"]`)<br/>
+Defines colours for use in conjunction with `todo-tree.highlights.backgroundColourScheme` to colour highlights. These colours should be complementary to the background colours.
 
 **todo-tree.regex.regex** (<tt>&#x22;&#x28;&#x28;&#x2f;&#x2f;&#x7c;&#x23;&#x7c;&#x3c;&#x21;&#x2d;&#x2d;&#x7c;&#x3b;&#x7c;&#x2f;&#x5c;&#x5c;&#x2a;&#x29;&#x5c;&#x5c;&#x73;&#x2a;&#x28;&#x24;&#x54;&#x41;&#x47;&#x53;&#x29;&#x7c;&#x5e;&#x5c;&#x5c;&#x73;&#x2a;&#x2d;&#x20;&#x5c;&#x5c;&#x5b;&#x20;&#x5c;&#x5c;&#x5d;&#x29;&#x22;</tt>)<br/>
 This defines the regex used to locate TODOs. By default, it searches for tags in comments starting with <tt>&#47;&#47;</tt>, <tt>#</tt>, <tt>;</tt>, <tt>&lt;!--</tt> or <tt>&#47;*</tt>. This should cover most languages. However if you want to refine it, make sure that the <tt>($TAGS)</tt> is kept. The second part of the expression allows matching of Github markdown task lists. *Note: This is a [Rust regular expression](https://docs.rs/regex/1.0.0/regex)</a>, not javascript.*

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "activationEvents": [
         "*"
     ],
-    "main": "./dist/extension",
+    "main": "./src/extension.js",
     "contributes": {
         "viewsContainers": {
             "activitybar": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "tasklist",
         "multi-root ready"
     ],
-    "version": "0.0.192",
+    "version": "0.0.193",
     "license": "MIT",
     "icon": "resources/todo-tree.png",
     "publisher": "Gruntfuggly",
@@ -587,6 +587,11 @@
                     "default": true,
                     "markdownDescription": "Use a case sensitive regular expression",
                     "type": "boolean"
+                },
+                "todo-tree.regex.rightOfTagReplacementRegex": {
+                    "default": "(^:\\s*)",
+                    "markdownDescription": "Regular expression for removing unwanted string from the right hand side of a tag.",
+                    "type": "string"
                 },
                 "todo-tree.ripgrep.ripgrep": {
                     "default": "",

--- a/package.json
+++ b/package.json
@@ -541,6 +541,43 @@
                     "markdownDescription": "Editor schemes to show highlights in. To show highlights in settings files, for instance, add 'vscode-userdata' or for output windows, use 'output'.",
                     "type": "array"
                 },
+                "todo-tree.highlights.useColourScheme": {
+                    "default": false,
+                    "markdownDescription": "Use a colour scheme to colour the tags. This scheme is applied to the tags in the order of tags. The colours can be modified using `todo-tree.highlights.foregroundColourScheme` and `todo-tree.highlights.backgroundColourScheme`. The colour scheme overrides colours in the default highlight, but not the custom highlight.",
+                    "type": "boolean"
+                },
+                "todo-tree.highlights.foregroundColourScheme": {
+                    "default": [
+                        "white",
+                        "black",
+                        "black",
+                        "white",
+                        "white",
+                        "white",
+                        "black"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "markdownDescription": "A list of colours which is applied to tag highlights in the same order as the tags. Repeats if necessary and is overridden by `todo-tre.highlights.customHighlights`.",
+                    "type": "array"
+                },
+                "todo-tree.highlights.backgroundColourScheme": {
+                    "default": [
+                        "red",
+                        "orange",
+                        "yellow",
+                        "green",
+                        "blue",
+                        "indigo",
+                        "violet"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "markdownDescription": "A list of colours which is applied to tag highlights in the same order as the tags. Repeats if necessary and is overridden by `todo-tre.highlights.customHighlights`.",
+                    "type": "array"
+                },
                 "todo-tree.regex.regex": {
                     "default": "((//|#|<!--|;|/\\*|^)\\s*($TAGS)|^\\s*- \\[ \\])",
                     "markdownDescription": "Regular expression for matching TODOs. *Note: $TAGS will be replaced by the tag list.*",

--- a/src/config.js
+++ b/src/config.js
@@ -68,6 +68,11 @@ function regex()
     };
 }
 
+function rightOfTagReplacementRegex()
+{
+    return vscode.workspace.getConfiguration( 'todo-tree.regex' ).get( 'rightOfTagReplacementRegex' );
+}
+
 function ripgrepPath()
 {
     function exeName()
@@ -227,6 +232,7 @@ module.exports.showFilterCaseSensitive = showFilterCaseSensitive;
 module.exports.isRegexCaseSensitive = isRegexCaseSensitive;
 module.exports.showBadges = showBadges;
 module.exports.regex = regex;
+module.exports.rightOfTagReplacementRegex = rightOfTagReplacementRegex;
 module.exports.ripgrepPath = ripgrepPath;
 module.exports.tags = tags;
 module.exports.shouldSortTagsOnlyViewAlphabetically = shouldSortTagsOnlyViewAlphabetically;

--- a/src/config.js
+++ b/src/config.js
@@ -97,7 +97,7 @@ function ripgrepPath()
 
 function tags()
 {
-    return vscode.workspace.getConfiguration( 'todo-tree.general' ).tags.sort().reverse();
+    return vscode.workspace.getConfiguration( 'todo-tree.general' ).tags.slice();
 }
 
 function shouldSortTagsOnlyViewAlphabetically()
@@ -190,6 +190,31 @@ function shouldShowScanModeInTree()
     return vscode.workspace.getConfiguration( 'todo-tree.tree' ).showCurrentScanMode;
 }
 
+function shouldUseColourScheme()
+{
+    return vscode.workspace.getConfiguration( 'todo-tree.highlights' ).useColourScheme;
+}
+
+function foregroundColourScheme()
+{
+    return vscode.workspace.getConfiguration( 'todo-tree.highlights' ).foregroundColourScheme;
+}
+
+function backgroundColourScheme()
+{
+    return vscode.workspace.getConfiguration( 'todo-tree.highlights' ).backgroundColourScheme;
+}
+
+function defaultHighlight()
+{
+    return vscode.workspace.getConfiguration( 'todo-tree.highlights' ).defaultHighlight;
+}
+
+function customHighlight()
+{
+    return vscode.workspace.getConfiguration( 'todo-tree.highlights' ).customHighlight;
+}
+
 module.exports.init = init;
 module.exports.shouldGroup = shouldGroup;
 module.exports.shouldExpand = shouldExpand;
@@ -219,3 +244,8 @@ module.exports.shouldHideFromStatusBar = shouldHideFromStatusBar;
 module.exports.shouldSortTree = shouldSortTree;
 module.exports.scanMode = scanMode;
 module.exports.shouldShowScanModeInTree = shouldShowScanModeInTree;
+module.exports.shouldUseColourScheme = shouldUseColourScheme;
+module.exports.foregroundColourScheme = foregroundColourScheme;
+module.exports.backgroundColourScheme = backgroundColourScheme;
+module.exports.defaultHighlight = defaultHighlight;
+module.exports.customHighlight = customHighlight;

--- a/src/config.js
+++ b/src/config.js
@@ -97,7 +97,8 @@ function ripgrepPath()
 
 function tags()
 {
-    return vscode.workspace.getConfiguration( 'todo-tree.general' ).tags.slice();
+    var tags = vscode.workspace.getConfiguration( 'todo-tree.general' ).tags;
+    return tags.length > 0 ? tags : [ "TODO" ];
 }
 
 function shouldSortTagsOnlyViewAlphabetically()

--- a/src/extension.js
+++ b/src/extension.js
@@ -13,6 +13,7 @@ var colours = require( './colours.js' );
 var highlights = require( './highlights.js' );
 var config = require( './config.js' );
 var utils = require( './utils.js' );
+var attributes = require( './attributes.js' );
 
 var searchResults = [];
 var searchList = [];
@@ -56,6 +57,7 @@ function activate( context )
     config.init( context );
     highlights.init( context );
     utils.init( config );
+    attributes.init( config );
 
     provider = new tree.TreeNodeProvider( context, debug );
     var status = vscode.window.createStatusBarItem( vscode.StatusBarAlignment.Left, 0 );
@@ -1043,6 +1045,19 @@ function activate( context )
                     }
                 }
             }
+            else
+            {
+                vscode.window.visibleTextEditors.map( editor =>
+                {
+                    if( config.shouldShowHighlights( editor.document.uri.scheme ) )
+                    {
+                        if( isIncluded( editor.document.fileName ) )
+                        {
+                            highlights.triggerHighlight( editor );
+                        }
+                    }
+                } );
+            }
         }
 
         function validateColours()
@@ -1463,14 +1478,14 @@ function activate( context )
                 }
 
                 if( e.affectsConfiguration( "todo-tree.highlights.enabled" ) ||
+                    e.affectsConfiguration( "todo-tree.highlights.useColourScheme" ) ||
+                    e.affectsConfiguration( "todo-tree.highlights.foregroundColourScheme" ) ||
+                    e.affectsConfiguration( "todo-tree.highlights.backgroundColourScheme" ) ||
                     e.affectsConfiguration( "todo-tree.highlights.defaultHighlight" ) ||
                     e.affectsConfiguration( "todo-tree.highlights.customHighlight" ) )
                 {
                     validateColours();
-                    if( vscode.window.activeTextEditor )
-                    {
-                        documentChanged( vscode.window.activeTextEditor.document );
-                    }
+                    documentChanged();
                 }
                 else if( e.affectsConfiguration( "todo-tree.general.debug" ) )
                 {

--- a/src/extension.js
+++ b/src/extension.js
@@ -938,6 +938,7 @@ function activate( context )
             migrateIfRequired( 'labelFormat', 'string', 'tree' );
             migrateIfRequired( 'passGlobsToRipgrep', 'boolean', 'filtering' );
             migrateIfRequired( 'regex', 'string', 'regex' );
+            migrateIfRequired( 'rightOfTagReplacementRegex' , 'string', 'regex' );
             migrateIfRequired( 'regexCaseSensitive', 'boolean', 'regex' );
             migrateIfRequired( 'revealBehaviour', 'string', 'general' );
             migrateIfRequired( 'ripgrep', 'string', 'ripgrep' );

--- a/src/highlights.js
+++ b/src/highlights.js
@@ -1,6 +1,5 @@
 var vscode = require( 'vscode' );
 
-var colours = require( './colours.js' );
 var config = require( './config.js' );
 var utils = require( './utils.js' );
 var attributes = require( './attributes.js' );
@@ -27,8 +26,8 @@ function init( context )
 
 function getDecoration( tag )
 {
-    var foregroundColour = getForeground( tag );
-    var backgroundColour = getBackground( tag );
+    var foregroundColour = attributes.getForeground( tag );
+    var backgroundColour = attributes.getBackground( tag );
 
     var opacity = getOpacity( tag );
 
@@ -127,16 +126,6 @@ function getDecoration( tag )
     decorationOptions.dark = { backgroundColor: darkBackgroundColour, color: darkForegroundColour };
 
     return vscode.window.createTextEditorDecorationType( decorationOptions );
-}
-
-function getForeground( tag )
-{
-    return attributes.getAttribute( tag, 'foreground', undefined );
-}
-
-function getBackground( tag )
-{
-    return attributes.getAttribute( tag, 'background', undefined );
 }
 
 function getRulerColour( tag, defaultColour )

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,7 +147,7 @@ function removeLineComments( text, fileName )
 
 function getTagRegex()
 {
-    var tags = config.tags().sort().reverse();
+    var tags = config.tags().slice().sort().reverse();
     tags = tags.map( function( tag )
     {
         tag = tag.replace( /\\/g, '\\\\\\' );

--- a/src/utils.js
+++ b/src/utils.js
@@ -171,12 +171,13 @@ function extractTag( text, matchOffset )
     if( c.regex.indexOf( "$TAGS" ) > -1 )
     {
         var tagRegex = new RegExp( getTagRegex(), flags );
+        var rightOfTagRegex = new RegExp( config.rightOfTagReplacementRegex(), flags );
 
         tagMatch = tagRegex.exec( text );
         if( tagMatch )
         {
             tagOffset = tagMatch.index;
-            rightOfTag = text.substr( tagMatch.index + tagMatch[ 0 ].length ).trim().replace( /^:\s*/, "" );
+            rightOfTag = text.substr( tagMatch.index + tagMatch[ 0 ].length ).trim().replace( rightOfTagRegex, "" );
             if( rightOfTag.length === 0 )
             {
                 text = text.substr( 0, matchOffset ? matchOffset - 1 : tagMatch.index ).trim();

--- a/test/stubs.js
+++ b/test/stubs.js
@@ -3,6 +3,7 @@ var testConfig = {
     shouldBeCaseSensitive: false,
     regexSource: "($TAGS)",
     tagList: [ "TODO" ],
+    rightOfTagReplacementRegexString: "(^:\\s*)",
     globsList: [],
     useColourScheme: false,
     foregroundColours: [],
@@ -33,6 +34,12 @@ testConfig.isRegexCaseSensitive = function()
 {
     return this.shouldBeCaseSensitive;
 };
+
+testConfig.rightOfTagReplacementRegex = function()
+{
+    return this.rightOfTagReplacementRegexString;
+};
+
 testConfig.shouldUseColourScheme = function()
 {
     return this.useColourScheme;

--- a/test/stubs.js
+++ b/test/stubs.js
@@ -3,8 +3,12 @@ var testConfig = {
     shouldBeCaseSensitive: false,
     regexSource: "($TAGS)",
     tagList: [ "TODO" ],
-    globsList: []
+    globsList: [],
+    useColourScheme: false,
+    foregroundColours: [],
+    backgroundColours: [],
 };
+
 testConfig.regex = function()
 {
     return {
@@ -28,6 +32,26 @@ testConfig.tags = function()
 testConfig.isRegexCaseSensitive = function()
 {
     return this.shouldBeCaseSensitive;
+};
+testConfig.shouldUseColourScheme = function()
+{
+    return this.useColourScheme;
+};
+testConfig.defaultHighlight = function()
+{
+    return {};
+};
+testConfig.customHighlight = function()
+{
+    return [];
+};
+testConfig.foregroundColourScheme = function()
+{
+    return this.foregroundColours;
+};
+testConfig.backgroundColourScheme = function()
+{
+    return this.backgroundColours;
 };
 
 function getTestConfig()

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,6 +1,7 @@
 var os = require( 'os' );
 var strftime = require( 'fast-strftime' );
 var utils = require( '../src/utils.js' );
+var attributes = require( '../src/attributes.js' );
 var stubs = require( './stubs.js' );
 
 QUnit.test( "utils.isHexColour", function( assert )
@@ -404,4 +405,38 @@ QUnit.test( "utils.setRgbAlpha", function( assert )
     assert.equal( utils.setRgbAlpha( "fail", 0.5 ), "fail" );
     assert.equal( utils.setRgbAlpha( "rgb(0,0,0)", 0.5 ), "rgba(0,0,0,0.5)" );
     assert.equal( utils.setRgbAlpha( "rgba(0,0,0,1.0)", 0.5 ), "rgba(0,0,0,0.5)" );
+} );
+
+QUnit.test( "attributes.getForeground uses colour scheme", function( assert )
+{
+    var testConfig = stubs.getTestConfig();
+    testConfig.useColourScheme = true;
+    testConfig.tagList = [
+        "FIXME",
+        "TODO",
+        "BUG"
+    ];
+    testConfig.foregroundColours = [ "red", "green" ];
+    attributes.init( testConfig );
+
+    assert.equal( attributes.getForeground( "FIXME" ), "red" );
+    assert.equal( attributes.getForeground( "TODO" ), "green" );
+    assert.equal( attributes.getForeground( "BUG" ), "red" );
+} );
+
+QUnit.test( "attributes.getBackground uses colour scheme", function( assert )
+{
+    var testConfig = stubs.getTestConfig();
+    testConfig.useColourScheme = true;
+    testConfig.tagList = [
+        "FIXME",
+        "TODO",
+        "BUG"
+    ];
+    testConfig.backgroundColours = [ "white", "#000" ];
+    attributes.init( testConfig );
+
+    assert.equal( attributes.getBackground( "FIXME" ), "white" );
+    assert.equal( attributes.getBackground( "TODO" ), "#000" );
+    assert.equal( attributes.getBackground( "BUG" ), "white" );
 } );

--- a/test/tests.js
+++ b/test/tests.js
@@ -124,6 +124,24 @@ QUnit.test( "utils.extractTag removes colon from ${after}", function( assert )
     assert.equal( result, "TODO: after" );
 } );
 
+QUnit.test( "utils.extractTag removes custom regex from ${after}", function( assert )
+{
+    var testConfig = stubs.getTestConfig();
+    testConfig.rightOfTagReplacementRegexString = "(^--\\s*)";
+    utils.init( testConfig );
+
+    result = utils.extractTag( "before TODO-- after" );
+    assert.equal( result.withoutTag, "after" );
+
+    result = utils.extractTag( "before TODO -- after" );
+    assert.equal( result.withoutTag, "after" );
+
+    result = utils.extractTag( "before TODO --after" );
+    assert.equal( result.withoutTag, "after" );
+    result = utils.formatLabel( "${tag}-- ${after}", { actualTag: result.tag, after: result.withoutTag } );
+    assert.equal( result, "TODO-- after" );
+} );
+
 QUnit.test( "utils.extractTag returns text from the start of the line if the tag is on then end", function( assert )
 {
     var testConfig = stubs.getTestConfig();


### PR DESCRIPTION
Tiny extra config addition: Allowing the user to have a custom regex filter for the right hand side of a tag.
The default is to do the same as before this commit: Strip away any colons (":") from the right hand side of tags. 
This can cause issues if the user has a different separator then a colon or (In my case at least) wrap tags in characters like square brackets. 
While regex can be used to filter them out, the tag formatter will only remove the left hand symbol/s and leave the right resulting in strings such as "TODO ] Fix this..." rather than "TODO Fix this".