### PR TITLE
Update regex for Multiline suggestions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Show a button in the tree view title bar to create a text file showing the tree 
 If the regex contains `\n`, then multiline TODOs will be enabled. In this mode, the search results are processed slightly differently. If results are found which do not contain any tags from `todo-tree.general.tags` it will be assumed that they belong to the previous result that did have a tag. For example, if you set the regex to something like:
 
 ```json
-"todo-tree.regex.regex": "(\/\/) *($TAGS).*((\\s)+\/\/\\s{2,}.*)*"
+"todo-tree.regex.regex": "\/\/\\s*($TAGS).*(\\s+\/\/\\s{2,}.*)*",
 ```
 
 This will now match multiline TODOs where the extra lines have at least two spaces between the comment characters and the TODO item. e.g.
@@ -379,7 +379,7 @@ This will now match multiline TODOs where the extra lines have at least two spac
 If you want to match multiline TODOs in C++ style multiline comment blocks, you'll need something like:
 
 ```json
-"todo-tree.regex.regex": "(\/\\*)\\s*($TAGS).*((\\s+(\/\/|\/\\*|\\*\\*)\\s{2,}.*)*\\s*\\*\/)*",
+"todo-tree.regex.regex": "\/\\*\\s*($TAGS).*((\\s+(\/\/|\/\\*|\\*\\*)\\s{2,}.*)*\\s*\\*\/)*",
 ```
 
 which should match:

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Show a button in the tree view title bar to create a text file showing the tree 
 If the regex contains `\n`, then multiline TODOs will be enabled. In this mode, the search results are processed slightly differently. If results are found which do not contain any tags from `todo-tree.general.tags` it will be assumed that they belong to the previous result that did have a tag. For example, if you set the regex to something like:
 
 ```json
-"todo-tree.regex.regex": "(//)\\s*($TAGS).*(\\n\\s*//\\s{2,}.*)*"
+"todo-tree.regex.regex": "(\/\/) *($TAGS).*((\\s)+\/\/\\s{2,}.*)*"
 ```
 
 This will now match multiline TODOs where the extra lines have at least two spaces between the comment characters and the TODO item. e.g.
@@ -379,7 +379,7 @@ This will now match multiline TODOs where the extra lines have at least two spac
 If you want to match multiline TODOs in C++ style multiline comment blocks, you'll need something like:
 
 ```json
-"todo-tree.regex.regex": "(/\\*)\\s*($TAGS).*(\\n\\s*(//|/\\*|\\*\\*)\\s{2,}.*)*"
+"todo-tree.regex.regex": "(\/\\*)\\s*($TAGS).*((\\s+(\/\/|\/\\*|\\*\\*)\\s{2,}.*)*\\s*\\*\/)*",
 ```
 
 which should match:


### PR DESCRIPTION
I could not get the regex suggestions in the README files to work for my system.

I made some changes to them to make them work on my system.

This regex should be cross-platform compatible and works great on my Windows system\
(_even if it does increase the processor usage for todo-tree_)