### PR TITLE
Add additional ${name:func} substitutions for labelFormat

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -285,26 +285,34 @@ function formatLabel( template, node, unexpectedPlaceholders )
 {
     var result = template;
 
-    var subTag = node.subTag ? node.subTag : "";
+    var tag = String(node.actualTag).trim();
+    var subTag = node.subTag ? String(node.subTag).trim() : "";
+    var filename = node.fsPath ? path.basename( node.fsPath ) : "";
+    var filepath = node.fsPath ? node.fsPath : "";
 
-    result = result.replace( /\$\{line\}/g, ( node.line + 1 ) );
-    result = result.replace( /\$\{column\}/g, node.column );
-    result = result.replace( /\$\{tag\}/g, node.actualTag );
-    result = result.replace( /\$\{subTag\}/g, subTag );
-    result = result.replace( /\$\{subtag\}/g, subTag );
-    result = result.replace( /\$\{after\}/g, node.after );
-    result = result.replace( /\$\{before\}/g, node.before );
-    result = result.replace( /\$\{afterOrBefore\}/g, ( ( node.after === "" ) ? node.before : node.after ) );
-    if( node.fsPath )
-    {
-        result = result.replace( /\$\{filename\}/g, path.basename( node.fsPath ) );
-        result = result.replace( /\$\{filepath\}/g, node.fsPath );
+    var formatLabelMap = {
+      "line": node.line + 1,
+      "column": node.column,
+      "tag": tag,
+      "tag:uppercase": tag.toUpperCase(),
+      "tag:lowercase": tag.toLowerCase(),
+      "tag:capitalize": tag.charAt(0).toUpperCase() + tag.slice(1),
+      "subtag": subTag,
+      "subtag:uppercase": subTag.toUpperCase(),
+      "subtag:lowercase": subTag.toLowerCase(),
+      "subtag:capitalize": ( subTag === "" ) ? "" : subTag.charAt(0).toUpperCase() + subTag.slice(1),
+      "before": node.before,
+      "after": node.after,
+      "afterOrBefore": ( node.after === "" ) ? node.before : node.after,
+      "filename": filename,
+      "filepath": filepath
     }
-    else
-    {
-        result = result.replace( /\$\{filename\}/g, "" );
-        result = result.replace( /\$\{filepath\}/g, "" );
-    }
+
+    // prepare regex to substitude "${name}" with it's value from map
+    var re = new RegExp("\\$\\{(" + Object.keys(formatLabelMap).join("|") + ")\\}", "gi");
+    result = result.replace(re, function(matched){
+      return formatLabelMap[matched.slice(2, -1).toLowerCase()];
+    });
 
     if( unexpectedPlaceholders )
     {

--- a/test/tests.js
+++ b/test/tests.js
@@ -313,10 +313,24 @@ QUnit.test( "utils.formatLabel replaces before text placeholder", function( asse
     assert.equal( unexpectedPlaceholders.length, 0 );
 } );
 
-QUnit.test( "utils.formatLabel replaces tag placeholder", function( assert )
+QUnit.test( "utils.formatLabel replaces tag placeholders", function( assert )
 {
     var unexpectedPlaceholders = [];
-    assert.equal( utils.formatLabel( "Label ${tag} content", { actualTag: "TODO" }, unexpectedPlaceholders ), "Label TODO content" );
+    assert.equal( utils.formatLabel( "Label ${tag} content", { actualTag: "Todo" }, unexpectedPlaceholders ), "Label Todo content" );
+    assert.equal( utils.formatLabel( "Label ${tag:uppercase} content", { actualTag: "todo" }, unexpectedPlaceholders ), "Label TODO content" );
+    assert.equal( utils.formatLabel( "Label ${tag:lowercase} content", { actualTag: "TODO" }, unexpectedPlaceholders ), "Label todo content" );
+    assert.equal( utils.formatLabel( "Label ${tag:capitalize} content", { actualTag: "todo" }, unexpectedPlaceholders ), "Label Todo content" );
+    assert.equal( unexpectedPlaceholders.length, 0 );
+} );
+
+QUnit.test( "utils.formatLabel replaces sub tag placeholders", function( assert )
+{
+    var unexpectedPlaceholders = [];
+    assert.equal( utils.formatLabel( "Label ${subTag} content", { subTag: "name@mail.com" }, unexpectedPlaceholders ), "Label name@mail.com content" );
+    assert.equal( utils.formatLabel( "Label ${subtag} content", { subTag: "Name@mail.com" }, unexpectedPlaceholders ), "Label Name@mail.com content" );
+    assert.equal( utils.formatLabel( "Label ${subtag:uppercase} content", { subTag: "example" }, unexpectedPlaceholders ), "Label EXAMPLE content" );
+    assert.equal( utils.formatLabel( "Label ${subtag:lowercase} content", { subTag: "EXAMPLE" }, unexpectedPlaceholders ), "Label example content" );
+    assert.equal( utils.formatLabel( "Label ${subtag:capitalize} content", { subTag: "example" }, unexpectedPlaceholders ), "Label Example content" );
     assert.equal( unexpectedPlaceholders.length, 0 );
 } );
 
@@ -354,13 +368,6 @@ QUnit.test( "utils.formatLabel doesn't report errors if fileName or filePath is 
     assert.equal( utils.formatLabel( "Label ${filepath} content", {}, unexpectedPlaceholders ), "Label  content" );
     assert.equal( unexpectedPlaceholders.length, 0 );
     assert.equal( utils.formatLabel( "Label ${filename} content", {}, unexpectedPlaceholders ), "Label  content" );
-    assert.equal( unexpectedPlaceholders.length, 0 );
-} );
-
-QUnit.test( "utils.formatLabel replaces sub tag placeholder", function( assert )
-{
-    var unexpectedPlaceholders = [];
-    assert.equal( utils.formatLabel( "Label ${subTag} content", { subTag: "name@mail.com" }, unexpectedPlaceholders ), "Label name@mail.com content" );
     assert.equal( unexpectedPlaceholders.length, 0 );
 } );
 


### PR DESCRIPTION
This PR makes it possible to scan for upperCase and lowerCase tags or case insensitive but to show tag labels in a general upperCase manner inside the tree views.

Makes it much more easier to get through the tree views.
