### PR TITLE
add Lua comments to the regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -717,7 +717,7 @@
                     "type": "array"
                 },
                 "todo-tree.regex.regex": {
-                    "default": "((//|#|<!--|;|/\\*|^)\\s*($TAGS)|^\\s*- \\[ \\])",
+                    "default": "((//|#|--\[*|;|/\\*|^)\\s*($TAGS)|^\\s*- \\[ \\])",
                     "markdownDescription": "%todo-tree.configuration.regex.regex.markdownDescription%",
                     "type": "string"
                 },


### PR DESCRIPTION
Lua comments start with `--` or `--[[` (latter is long-comment), the added
regex for this is `--\[*`. Since that also matches XML comments (which
was `<!--`), I replaced that one.