### PR TITLE
Adding switchScope command

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ To make it easier to configure the tags, there are two commands available:
 
 The contents of the tree can be exported using **Todo Tree: Export Tree**. A read-only file will be created using the path specified with `todo-tree.general.exportPath`. The file can be saved using **File: Save As...**. *Note: Currently **File: Save** does not work which seems to be a VSCode bug (see <https://github.com/microsoft/vscode/issues/101952>).*
 
+### Switch Scope
+
+**Todo Tree: Switch Scope** - shows a list of configured scopes which can be selected
+
 ## Configuration
 
 The extension can be customised as follows (default values in brackets):
@@ -416,6 +420,29 @@ Show a button in the tree view title bar to expand or collapse the whole tree.
 Show a button in the tree view title bar to create a text file showing the tree content.
 
 <sup>*</sup>*Only applies to new workspaces. Once the view has been changed in the workspace, the current state is stored.*
+
+
+**todo-tree.scopes** (`{}`)</br>
+Defines a set of file scopes that can be quickly swicthed between using the *todo-tree.switchScope* command.
+
+This is a complex configuration property that can only be configured through the configuration JSON file. For example
+
+```json
+"todo-tree.scopes": [
+    {
+        "name": "Production ",
+        "excludeGlobs": "**/tests/**" 
+    },
+    {
+        "name": "Tests",
+        "includeGlobs": "**/tests/**" 
+    },
+    {
+        "name": "All"
+    }
+]
+```
+
 
 ### Multiline TODOs
 

--- a/package.json
+++ b/package.json
@@ -424,6 +424,12 @@
                 "icon": "$(filter)"
             },
             {
+                "command": "todo-tree.switchScope",
+                "title": "%todo-tree.command.switchScope.title%",
+                "category": "%todo-tree.command.category%",
+                "icon": "$(filter)"
+            },
+            {
                 "command": "todo-tree.excludeThisFolder",
                 "title": "%todo-tree.command.excludeThisFolder.title%",
                 "category": "%todo-tree.command.category%",
@@ -932,6 +938,11 @@
                     "default": true,
                     "markdownDescription": "%todo-tree.configuration.tree.trackFile.markdownDescription%",
                     "type": "boolean"
+                },
+                "todo-tree.scopes": {
+                    "default": [],
+                    "markdownDescription": "%todo-tree.configuration.scopes.markdownDescription%",
+                    "type": "array"
                 }
             }
         }

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,6 +23,7 @@
     "todo-tree.command.exportTree.title": "Export Tree",
     "todo-tree.command.showOnlyThisFolder.title": "Only Show This Folder",
     "todo-tree.command.showOnlyThisFolderAndSubfolders.title": "Only Show This Folder And Subfolders",
+    "todo-tree.command.switchScope.title": "Switch Scope",
     "todo-tree.command.excludeThisFolder.title": "Hide This Folder",
     "todo-tree.command.excludeThisFile.title": "Hide This File",
     "todo-tree.command.removeFilter.title": "Remove Filter",
@@ -120,5 +121,6 @@
     "todo-tree.configuration.tree.sort.markdownDescription": "ripgrep searches using multiple threads to improve performance. The tree is sorted when it is populated so that it stays stable. If you want to use ripgrep's own sort arguments, set this to false.",
     "todo-tree.configuration.tree.tagsOnly.markdownDescription": "When opening new workspaces, show only tag elements in tree.",
     "todo-tree.configuration.tree.tooltipFormat.markdownDescription": "Tree item tooltip format.",
-    "todo-tree.configuration.tree.trackFile.markdownDescription": "Track the current file in the tree view."
+    "todo-tree.configuration.tree.trackFile.markdownDescription": "Track the current file in the tree view.",
+    "todo-tree.configuration.scopes.markdownDescription": "Scopes (sets of globs) that can be switched between"
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -1309,6 +1309,34 @@ function activate( context )
             dumpFolderFilter();
         } ) );
 
+        context.subscriptions.push( vscode.commands.registerCommand( 'todo-tree.switchScope', function()
+        {
+            var config = vscode.workspace.getConfiguration( 'todo-tree' ).get( 'scopes' );
+
+            if (!config || config.length === 0) 
+            {
+                vscode.window.showWarningMessage("No scopes configured (see todo-tree.scopes setting)")
+            }
+            else
+            {
+                vscode.window.showQuickPick(config.map(c => c.name)).then(
+                    function( term ) 
+                    {
+                        var currentConfig = config.find(c => c.name === term);
+    
+                        var includeGlobs = currentConfig.includeGlobs ? [ currentConfig.includeGlobs ] : [];
+                        context.workspaceState.update( 'includeGlobs', includeGlobs );
+    
+                        var excludeGlobs = currentConfig.excludeGlobs ? [ currentConfig.excludeGlobs ] : [];
+                        context.workspaceState.update( 'excludeGlobs', excludeGlobs );
+    
+                        rebuild();
+                        dumpFolderFilter();
+                    } );
+            }
+
+        } ) );
+
         context.subscriptions.push( vscode.commands.registerCommand( 'todo-tree.excludeThisFolder', function( node )
         {
             var rootNode = tree.locateWorkspaceNode( node.fsPath );


### PR DESCRIPTION
This PR is related to https://github.com/Gruntfuggly/todo-tree/issues/482

It adds the ability to configure multiple different "scopes", i.e. a named combinations of `includeGlobs` and `excludeGlobs`. 

The idea is that you can define a glob that only includes test files, something like `**/test/**` and maybe integration tests using `**/integration-tests/**`. You can then quickly show/filter certain parts of the todo tree.