### PR TITLE
Update default regex to not match newlines and improve cleanup Markdown list matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ This is a complex configuration property that can only be configured through the
 If the regex contains `\n`, then multiline TODOs will be enabled. In this mode, the search results are processed slightly differently. If results are found which do not contain any tags from `todo-tree.general.tags` it will be assumed that they belong to the previous result that did have a tag. For example, if you set the regex to something like:
 
 ```json
-"todo-tree.regex.regex": "(//)\\s*($TAGS).*(\\n\\s*//\\s{2,}.*)*"
+"todo-tree.regex.regex": "(//)[ \\t]*($TAGS).*(\\n[ \\t]*//[ \\t]{2,}.*)*"
 ```
 
 This will now match multiline TODOs where the extra lines have at least two spaces between the comment characters and the TODO item. e.g.
@@ -477,7 +477,7 @@ This will now match multiline TODOs where the extra lines have at least two spac
 If you want to match multiline TODOs in C++ style multiline comment blocks, you'll need something like:
 
 ```json
-"todo-tree.regex.regex": "(/\\*)\\s*($TAGS).*(\\n\\s*(//|/\\*|\\*\\*)\\s{2,}.*)*"
+"todo-tree.regex.regex": "(/\\*)[ \\t]*($TAGS).*(\\n[ \\t]*(//|/\\*|\\*\\*)[ \\t]{2,}.*)*"
 ```
 
 which should match:
@@ -510,7 +510,7 @@ You can also include and exclude folders from the tree using the context menu. T
 When the extension was first written, very basic markdown support was added simply by adding a pattern to the default regex to match "`- [ ]`". A better way to handle markdown TODOs is to add "`(-|\d+.)`" to the list of "comments" in the first part of the regex and then adding "`[ ]`" and "`[x]`" to the list of tags in `settings.json`, e.g. :
 
 ```json
-"todo-tree.regex.regex": "(//|#|<!--|;|/\\*|^|^\\s*(-|\\d+.))\\s*($TAGS)"
+"todo-tree.regex.regex": "(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+\\.)[ \\t])[ \\t]*($TAGS)"
 "todo-tree.general.tags": [
         "BUG",
         "HACK",

--- a/package.json
+++ b/package.json
@@ -1104,7 +1104,7 @@
                 "type": "object",
                 "properties": {
                     "todo-tree.regex.regex": {
-                        "default": "(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
+                        "default": "(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+\\.)[ \\t])[ \\t]*($TAGS)",
                         "markdownDescription": "%todo-tree.configuration.regex.regex.markdownDescription%",
                         "type": "string",
                         "minLength": 1,

--- a/src/extension.js
+++ b/src/extension.js
@@ -983,7 +983,7 @@ function activate( context )
                         ignoreMarkdownUpdate = true;
                         addTag( '[ ]' );
                         addTag( '[x]' );
-                        c.update( 'regex.regex', '(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)', true );
+                        c.update( 'regex.regex', '(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+\\.)[ \\t])[ \\t]*($TAGS)', true );
                     }
                     else if( button === MORE_INFO_BUTTON )
                     {


### PR DESCRIPTION
I understand that changes to the default regex are rejected.  However, this PR does not change the default regex, but rather fixes a couple of issues with the default regex.

Here is the current regex, and the proposed regex _as entered in the Settings UI editor_
![image](https://user-images.githubusercontent.com/5075659/171543896-fb37acfc-6966-4fa0-812f-b15ccfe46661.png)

1. In the markdown numbered list match, escape the `.`
    * The unescaped period matched any character, causing lines like `1X TODO` to match
2. Enforce at least 1 space after `-` or `1.` 
    * This will fix lines like `1.TODO` or `-TODO` matching, as those are not valid markdown lists
3. Change the space before `($TAGS)` to only match spaces and tabs (not newlines)
    * This fixes #536 
