### PR TITLE
Add instructions for usage with Activitus Bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,21 @@ Lastly, it will allow grouping by tag (and sub tags) to work and also work bette
 
 <sup>*Note: The default regex will be updated to reflect these changes at some point in the future.*<sup>
 
+## Usage with other extensions
+
+### [Activitus Bar](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.activitusbar)
+
+To add Todo Tree to your Activitus Bar, open settings.json and add this entry to the `"activitusbar.views"` array:
+
+```json
+"activitusbar.views": [
+    {
+        "name": "extension.todo-tree-container",
+        "codicon": "checklist"
+    }
+]
+```
+
 ## Known Issues
 
 Grouping by tag will only work when your configuration defines the tags using the `todo-tree.general.tags` setting. Older versions of the extension had the tags directly defined in the `todo-tree.regex.regex` whereas now, the regex replaces **$TAGS** with the contents of `todo-tree.general.tags`.


### PR DESCRIPTION
It took me a few minutes to figure out how to add Todo Tree to my Activitus Bar. I thought it might be helpful for me to update the docs in case someone else needs to do this in the future I could save them the trouble and guesswork.

Here it is in my Activitus Bar to prove it works:

<img width="195" alt="image" src="https://user-images.githubusercontent.com/4197823/178285791-9843e1eb-eba6-4007-8362-0c01e075577c.png">
