### PR TITLE
Update excludeGlobs to exclude node_modules properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Globs for use in limiting search results by inclusion, e.g. `[\"**/unit-tests/*.
 
 <sup>*Note: globs paths are absolute - not relative to the current workspace.*</sup>
 
-**todo-tree.filtering.excludeGlobs** (`["**/node_modules"]`)</br>
+**todo-tree.filtering.excludeGlobs** (`["**/node_modules/*/**"]`)</br>
 Globs for use in limiting search results by exclusion (applied after **includeGlobs**), e.g. `[\"**/*.txt\"]` to ignore all .txt files.
 
 <sup>*Note: `node_modules` are excluded by default.*</sup>

--- a/package.json
+++ b/package.json
@@ -844,7 +844,7 @@
                     },
                     "todo-tree.filtering.excludeGlobs": {
                         "default": [
-                            "**/node_modules"
+                            "**/node_modules/*/**"
                         ],
                         "items": {
                             "type": "string"


### PR DESCRIPTION
![SCR-20220925-lpm](https://user-images.githubusercontent.com/10441177/192143791-e583ef3b-463b-43ec-b3bf-f52f6803a3b8.png)

P.S. VS Code also uses `**/node_modules/*/**` instead of `**/node_modules` in `files.watcherExclude` to exclude `node_modules`.