### PR TITLE
fix: Loss of todos sub tree when the subtag regex with match group is defined

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json -diff

--- a/package.json
+++ b/package.json
@@ -1167,18 +1167,18 @@
         "publisherDisplayName": "Gruntfuggly"
     },
     "dependencies": {
-        "@primer/octicons": "^16.0.0",
-        "comment-patterns": "^0.10.1",
+        "@primer/octicons": "^17.10.0",
+        "comment-patterns": "^0.12.2",
         "fast-strftime": "^1.1.1",
         "find": "^0.3.0",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.5",
         "regexp-match-indices": "^1.0.2",
         "treeify": "^1.1.0"
     },
     "devDependencies": {
         "parse-code-context": "^1.0.0",
-        "qunit": "^2.18.0",
-        "webpack": "^4.43.0",
-        "webpack-cli": "^3.3.12"
+        "qunit": "^2.19.3",
+        "webpack": "^5.75.0",
+        "webpack-cli": "^5.0.1"
     }
 }

--- a/src/tree.js
+++ b/src/tree.js
@@ -611,7 +611,7 @@ class TreeNodeProvider
                 {
                     var onlyChild = node.nodes.filter( isPathNode ).length === 1 ? node.nodes[ 0 ] : undefined;
                     var onlyChildParent = node;
-                    while( onlyChild && onlyChild.nodes.filter( isPathNode ).length > 0 && onlyChildParent.nodes.filter( isPathNode ).length === 1 )
+                    while( onlyChild && onlyChild.nodes && onlyChild.nodes.filter( isPathNode ).length > 0 && onlyChildParent.nodes.filter( isPathNode ).length === 1 )
                     {
                         treeItem.label += "/" + onlyChild.label;
                         onlyChildParent = onlyChild;


### PR DESCRIPTION
Cause:
![Screenshot from 2022-12-17 02-24-19](https://user-images.githubusercontent.com/14666676/208214826-206896b1-7e76-47f5-b9ed-f287ec99a298.png)

Also I've updated all dependencies to actual versions and especially the webpack because its old version for some reason didn't work correctly in my environment.