### PR TITLE
skip tree entry removal on workspace only mode

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1581,7 +1581,7 @@ function activate( context )
 
             delete openDocuments[ document.uri.toString() ];
 
-            if( vscode.workspace.getConfiguration( 'todo-tree.tree' ).autoRefresh === true )
+            if( vscode.workspace.getConfiguration( 'todo-tree.tree' ).autoRefresh === true && config.scanMode() !== SCAN_MODE_WORKSPACE_ONLY )
             {
                 if( config.isValidScheme( document.uri ) )
                 {


### PR DESCRIPTION
do not remove tree entries on file close for workspace only mode. This fixes https://github.com/Gruntfuggly/todo-tree/issues/714