### PR TITLE
Bug fix: Tags are matching at start of a line

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ You can also include and exclude folders from the tree using the context menu. T
 When the extension was first written, very basic markdown support was added simply by adding a pattern to the default regex to match "`- [ ]`". A better way to handle markdown TODOs is to add "`(-|\d+.)`" to the list of "comments" in the first part of the regex and then adding "`[ ]`" and "`[x]`" to the list of tags in `settings.json`, e.g. :
 
 ```json
-"todo-tree.regex.regex": "(//|#|<!--|;|/\\*|^|^\\s*(-|\\d+.))\\s*($TAGS)"
+"todo-tree.regex.regex": "(//|#|<!--|;|/\\*|^\\s*(-|\\d+.))\\s*($TAGS)"
 "todo-tree.general.tags": [
         "BUG",
         "HACK",

--- a/package.json
+++ b/package.json
@@ -1136,7 +1136,7 @@
                 "type": "object",
                 "properties": {
                     "todo-tree.regex.regex": {
-                        "default": "(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
+                        "default": "(//|#|<!--|;|/\\*|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
                         "markdownDescription": "%todo-tree.configuration.regex.regex.markdownDescription%",
                         "type": "string",
                         "minLength": 1,

--- a/src/extension.js
+++ b/src/extension.js
@@ -1008,7 +1008,7 @@ function activate( context )
                         ignoreMarkdownUpdate = true;
                         addTag( '[ ]' );
                         addTag( '[x]' );
-                        c.update( 'regex.regex', '(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)', true );
+                        c.update( 'regex.regex', '(//|#|<!--|;|/\\*|^[ \\t]*(-|\\d+.))\\s*($TAGS)', true );
                     }
                     else if( button === MORE_INFO_BUTTON )
                     {


### PR DESCRIPTION
### Reason

The symbol '^' in the regex causes the matching of tags at the start of a line.

### Details of implications

The regex of Todo Tree has the symbol “^” that asserts position at the start of a line. The problem occurs because there are many general matches and causes many false matching. See some examples below.

### Example 1: C/C++ structs and defines.

In the Linux Kernel code (https://kernel.org), there are structs such as `BUG_ON` and `BUG_ENTRY` in many parts of the code.

```c
BUG_ENTRY(PPC_TLNEI " %4, 0", 0, "r" ((__force long)(x)));
```

So, the extension will match all structs. This behavior should not be expected.

### Example 2: Text or LaTeX files.

If you write a text in LaTeX starting with:

```
BUG is an insect.
```

The extension will match part of the text. This behavior should not be expected.

### Example 3: Functions in shell scripts.

```sh
BUG_HANDLER () {
    echo "Test"
}
```

The extension will match the function `BUG_HANDLER`. This behavior should not be expected.
