### PR TITLE
Add link to explanations about the culture regarding tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Todo Tree
 
-This extension quickly searches (using [ripgrep](https://github.com/BurntSushi/ripgrep)) your workspace for comment tags like TODO and FIXME, and displays them in a tree view in the activity bar. The view can be dragged out of the activity bar into the explorer pane (or anywhere else you would prefer it to be).
+This extension quickly searches (using [ripgrep](https://github.com/BurntSushi/ripgrep)) your workspace for comment [tags](https://en.wikipedia.org/wiki/Comment_(computer_programming)#Tags) like TODO and FIXME, and displays them in a tree view in the activity bar. The view can be dragged out of the activity bar into the explorer pane (or anywhere else you would prefer it to be).
 
 Clicking a TODO within the tree will open the file and put the cursor on the line containing the TODO.
 


### PR DESCRIPTION
Thank you for great extension !
I always use it, thank you.

## Suggestion
How about adding links to explanations about the culture regarding tags(ex: _TODO_ or _FIXME_)?

## Reason
Because  documenting the culture of adding _TODO_ or _FIXME_ comments in the source code is to make more people aware of this fantastic extension.

The added link is here.

- [Comment \(computer programming\) \- Wikipedia](https://en.wikipedia.org/wiki/Comment_(computer_programming)#Tags)