### PR TITLE
Group by tag mode drops todos fix

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -981,7 +981,7 @@ class TreeNodeProvider
             {
                 keep = false;
             }
-            else if( child.fsPath === fullPath || child.isRootTagNode )
+            else if( child.fsPath === fullPath || (child.isRootTagNode && config.shouldShowTagsOnly()) )
             {
                 if( config.shouldShowTagsOnly() )
                 {

--- a/src/tree.js
+++ b/src/tree.js
@@ -981,22 +981,19 @@ class TreeNodeProvider
             {
                 keep = false;
             }
-            else if( child.fsPath === fullPath || (child.isRootTagNode && config.shouldShowTagsOnly()) )
+            else if ( config.shouldShowTagsOnly() && ( child.fsPath === fullPath || child.isRootTagNode ) )
             {
-                if( config.shouldShowTagsOnly() )
+                if( child.nodes )
                 {
-                    if( child.nodes )
+                    child.nodes = child.nodes.filter( function( node )
                     {
-                        child.nodes = child.nodes.filter( function( node )
-                        {
-                            return isTodoNode( node ) && node.fsPath !== fullPath;
-                        } );
-                    }
+                        return isTodoNode( node ) && node.fsPath !== fullPath;
+                    } );
                 }
-                else
-                {
-                    child.nodes = [];
-                }
+            }
+            else if ( !config.shouldShowTagsOnly() && child.fsPath === fullPath )
+            {
+                child.nodes = [];
             }
             return keep;
         }, this );


### PR DESCRIPTION
This PR is a fix for #749 (while also maintaining the fix for #562)

In full transparency, I don't really understand how the `TreeNodeProvider.reset` method works.  This PR is my attempt to merge the fix for both issues despite a lack of understanding of the logic.  More details on this fix can be found [here](https://github.com/Gruntfuggly/todo-tree/issues/749#issuecomment-1986880508)

I've done some testing of all the different TODOs view modes (flat/list/tags-only and group-by tags on/off) and it seems to fix both issues without other side effects.

@Gruntfuggly I think a fix for #749 should be considered a high priority as it is causing todos to not be displayed.  Please let me know if I can help in any way.