### PR TITLE
Default settings: Support common types of documentation comment and @todo tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1137,7 +1137,7 @@
                 "type": "object",
                 "properties": {
                     "todo-tree.regex.regex": {
-                        "default": "(//|///|#|<!--|;|/\\*|/\\*\\*|/\\*!|\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
+                        "default": "(//|///|#|\"\"\"|<!--|;|/\\*|/\\*\\*|/\\*!|\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
                         "markdownDescription": "%todo-tree.configuration.regex.regex.markdownDescription%",
                         "type": "string",
                         "minLength": 1,

--- a/package.json
+++ b/package.json
@@ -610,6 +610,7 @@
                             "HACK",
                             "FIXME",
                             "TODO",
+                            "@todo",
                             "XXX",
                             "[ ]",
                             "[x]"
@@ -1136,7 +1137,7 @@
                 "type": "object",
                 "properties": {
                     "todo-tree.regex.regex": {
-                        "default": "(//|#|<!--|;|/\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
+                        "default": "(//|#|<!--|;|/\\*|/\\*\\*|/\\*!|\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
                         "markdownDescription": "%todo-tree.configuration.regex.regex.markdownDescription%",
                         "type": "string",
                         "minLength": 1,

--- a/package.json
+++ b/package.json
@@ -1137,7 +1137,7 @@
                 "type": "object",
                 "properties": {
                     "todo-tree.regex.regex": {
-                        "default": "(//|///|#|\"\"\"|<!--|;|/\\*|/\\*\\*|/\\*!|\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
+                        "default": "(//|///|//!|#|\"\"\"|<!--|;|/\\*|/\\*\\*|/\\*!|\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
                         "markdownDescription": "%todo-tree.configuration.regex.regex.markdownDescription%",
                         "type": "string",
                         "minLength": 1,

--- a/package.json
+++ b/package.json
@@ -1137,7 +1137,7 @@
                 "type": "object",
                 "properties": {
                     "todo-tree.regex.regex": {
-                        "default": "(//|#|<!--|;|/\\*|/\\*\\*|/\\*!|\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
+                        "default": "(//|///|#|<!--|;|/\\*|/\\*\\*|/\\*!|\\*|^|^[ \\t]*(-|\\d+.))\\s*($TAGS)",
                         "markdownDescription": "%todo-tree.configuration.regex.regex.markdownDescription%",
                         "type": "string",
                         "minLength": 1,


### PR DESCRIPTION
Adds `@todo` as a default tag and makes the default regex support comments starting with:
* `/**` (start of a Javadoc standard doc comment)
* `*` (start of a new line of a doc comment)
* `/*!` (Qt-style or important comment block)
* `///` (C# and Doxygen)
* `//!` (Doxygen)
* `"""` (Python docstring)

Inspired by [this page](https://www.doxygen.nl/manual/docblocks.html#cppblock) of the Doxygen docs.

Tested in RegExr:
![image](https://github.com/user-attachments/assets/dd781113-e836-451d-b6b1-4515f76af949)