### PR TITLE
Added support for Powershell based environments.

### DIFF
--- a/src/ripgrep.js
+++ b/src/ripgrep.js
@@ -115,6 +115,11 @@ module.exports.search = function ripGrep( cwd, options )
     }
 
     let execString = rgPath + ' --no-messages --vimgrep -H --column --line-number --color never ' + options.additional;
+
+    if (process.env.ComSpec && process.env.ComSpec.toLowerCase().includes("powershell")) {
+        execString = "&" + execString;
+    }
+
     if( options.multiline )
     {
         execString += " -U ";


### PR DESCRIPTION
If Vs Code is run with PowerShell as system/session default command line interpreter the `ripgrep` command fails.

E.g: Changed the `ComSpec` environment variable to `"powershell.exe"`.

This takes into account the current set CLI and updates the command with the "&" required on Powershell to run quoted commands.